### PR TITLE
Add watchdog dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Pygments==2.2.0
 python-frontmatter==0.4.2
 PyYAML==3.12
 six==1.10.0
+watchdog==0.8.3


### PR DESCRIPTION
This commit fixes a bug where requirements.txt does *not* have the
`watchdog` package listed as a dependency.

Thus, when usesrs install vsg's dependencies, they will be missing a
core package required by vsg.

Reviewed-by: Dom Rodriguez <shymega@shymega.org.uk>
Tested-by: Dom Rodriguez <shymega@shymega.org.uk>

(This is related to #10)