### PR TITLE
README: Add dependency installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,7 @@ Now, install vsg's dependencies. You _can_ do it with a virtualenv,
 but for the purposes of this README, we'll just do it as a user-level
 PyPi installation:
 
-    pip install --user -U -r ./vsg/requirements.txt
-
-(Make sure to use the Python 3 version of the `pip` utility on your
-system - otherwise vsg **won't** see the installed dependencies!)
+    pip3 install --user -U -r ./vsg/requirements.txt
 
 Now put configuration in `config.py` and write a template in
 `template.py`. Feel free to look at `example/template.py` for reference.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ root of your site as `build.py`:
     git submodule add https://github.com/vktec/vsg.git
     ln -s vsg/vsg.py build.py
 
+Now, install vsg's dependencies. You _can_ do it with a virtualenv,
+but for the purposes of this README, we'll just do it as a user-level
+PyPi installation:
+
+    pip install --user -U -r ./vsg/requirements.txt
+
+(Make sure to use the Python 3 version of the `pip` utility on your
+system - otherwise vsg **won't** see the installed dependencies!)
+
 Now put configuration in `config.py` and write a template in
 `template.py`. Feel free to look at `example/template.py` for reference.
 


### PR DESCRIPTION
This commit adds a section to the installation guide of vsg which
instructs the end-user on how to install `vsg`'s dependencies.

This fixes #11.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>
Tested-by: Dom Rodriguez <shymega@shymega.org.uk>
Reviewed-by: Dom Rodriguez <shymega@shymega.org.uk>